### PR TITLE
PLATFORM-1309 Add versioning for developer api documentation

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -30,6 +30,11 @@ module.exports = {
             description: 'v4.0 Current',
             path: '/api/current/index.md'
           },
+          {
+            title: 'Frame.io API',
+            description: 'Alpha Version',
+            path: '/api/alpha/index.md'
+          }
         ]
       }
     ],

--- a/src/pages/api/alpha/index.mdx
+++ b/src/pages/api/alpha/index.mdx
@@ -1,0 +1,5 @@
+---
+title: Frame.io Alpha API 
+description: The alpha version of the Frame.io API includes unproved, evolving features that may not be fully optimized or stable.
+openAPISpec: /v4/docs/alpha/openapi.json
+---

--- a/src/pages/api/current/index.mdx
+++ b/src/pages/api/current/index.mdx
@@ -1,5 +1,5 @@
 ---
 title: Frame.io API
 description: Frame.io customers can use our new V4-compatible REST API and webhooks to power custom workflows and automations.
-openAPISpec: /v4/openapi.json
+openAPISpec: /v4/docs/4.0/openapi.json
 ---


### PR DESCRIPTION
## PLATFORM-1309

## Description
Adding menu item to API Reference tab that links to Alpha version specs.

## Motivation and Context
This is needed so that customer developers can have access to Alpha version specs, so they can try out these experimental features.

## How Has This Been Tested?
I deployed to the staging site and made sure menu item was present and it linked to proper specs.

## Screenshots (if appropriate):
<img width="1176" alt="Screenshot 2024-12-05 at 10 10 58 AM" src="https://github.com/user-attachments/assets/fcddd978-3e33-42c8-a394-9536f1efe446">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
