### PR TITLE
Fixing Broken Custom Actions Link

### DIFF
--- a/src/pages/guides/Custom Actions/index.md
+++ b/src/pages/guides/Custom Actions/index.md
@@ -2,7 +2,7 @@
 
 Use the Custom Actions beta to build integrations directly into [Frame.io](https://next.frame.io/) as programmable UI components. This enables workflows that can be triggered by users within the app, leveraging the same underlying events routing as webhooks. You can create user-triggered single or multi-step forms that come back to Frame.io as another form or a basic response. And when a user clicks a Custom Action on an Asset, Frame.io sends a payload to a URL you provide. The receiving application responds with an HTTP status code to acknowledge receipt, or responds with a custom callback that can render additional UI in Frame.io.
 
-Configure [Custom Actions](https://developer-stage.adobe.com/frameio/api/alpha/#tag/Custom-Actions) in the Experimental API.
+Configure [Custom Actions](https://developer.adobe.com/frameio/api/experimental/#tag/Custom-Actions) in the Experimental API.
 <br/>
 
 |Field name	|Description	|


### PR DESCRIPTION
Fixing link to point to correct experimental API reference for Custom Actions